### PR TITLE
Tokenização retorna mensagem em caso de erro da Getnet

### DIFF
--- a/Model/NumberTokenManagement.php
+++ b/Model/NumberTokenManagement.php
@@ -189,7 +189,7 @@ class NumberTokenManagement implements NumberTokenManagementInterface
                 $response = [
                     'success' => 0,
                     'message' => [
-                        'text' => __("Error creating payment. Please, contact the store owner or try again."),
+                        'text' => __('Error creating payment. Please, contact the store owner or try again.'),
                     ],
                 ];
             }

--- a/Model/NumberTokenManagement.php
+++ b/Model/NumberTokenManagement.php
@@ -10,7 +10,6 @@ declare(strict_types=1);
 
 namespace Getnet\PaymentMagento\Model;
 
-use Exception;
 use Getnet\PaymentMagento\Api\Data\NumberTokenInterface;
 use Getnet\PaymentMagento\Api\NumberTokenManagementInterface;
 use Getnet\PaymentMagento\Gateway\Config\Config as ConfigBase;
@@ -173,7 +172,7 @@ class NumberTokenManagement implements NumberTokenManagementInterface
             $response = [
                 'success' => 0,
             ];
-            if (isset($data['number_token'])) {
+            if (!empty($data['number_token'])) {
                 $response = [
                     'success'      => 1,
                     'number_token' => $data['number_token'],
@@ -185,7 +184,16 @@ class NumberTokenManagement implements NumberTokenManagementInterface
                     'response' => $responseBody,
                 ]
             );
-        } catch (InvalidArgumentException $e) {
+            
+            if (!$client->request()->isSuccessful()) {
+                $response = [
+                    'success' => 0,
+                    'message' => [
+                        'text' => __("Error creating payment. Please, contact the store owner or try again.")
+                    ],
+                ];
+            }
+        } catch (\InvalidArgumentException $e) {
             $this->logger->debug(
                 [
                     'url'      => $url.'v1/tokens/card',
@@ -193,7 +201,7 @@ class NumberTokenManagement implements NumberTokenManagementInterface
                 ]
             );
             // phpcs:ignore Magento2.Exceptions.DirectThrow
-            throw new Exception('Invalid JSON was returned by the gateway');
+            throw new \Exception('Invalid JSON was returned by the gateway');
         }
 
         return $response;

--- a/Model/NumberTokenManagement.php
+++ b/Model/NumberTokenManagement.php
@@ -184,12 +184,12 @@ class NumberTokenManagement implements NumberTokenManagementInterface
                     'response' => $responseBody,
                 ]
             );
-            
+
             if (!$client->request()->isSuccessful()) {
                 $response = [
                     'success' => 0,
                     'message' => [
-                        'text' => __("Error creating payment. Please, contact the store owner or try again.")
+                        'text' => __("Error creating payment. Please, contact the store owner or try again."),
                     ],
                 ];
             }

--- a/i18n/en_US.csv
+++ b/i18n/en_US.csv
@@ -62,6 +62,7 @@ Finished,Finished
 "Payment release requested successfully","Payment release requested successfully"
 "Error: %1, description: %2","Error: %1, description: %2"
 "Error creating payment, please try again later. COD: 401","Error creating payment, please try again later. COD: 401"
+"Error creating payment. Please, contact the store owner or try again.","Error creating payment. Please, contact the store owner or try again."
 Getnet,Getnet
 Due,Due
 Instruction,Instruction

--- a/i18n/pt_BR.csv
+++ b/i18n/pt_BR.csv
@@ -62,6 +62,7 @@ Finished,Concluido
 "Payment release requested successfully","Liberação de pagamento solicitada com sucesso"
 "Error: %1, description: %2","Erro: %1, descrição: %2"
 "Error creating payment, please try again later. COD: 401","Erro ao criar o pagamento. Tente novamente mais tarde. CÓDIGO: 401"
+"Error creating payment. Please, contact the store owner or try again.","Erro ao criar o pagamento. Por favor, entre em contato com o lojista ou tente novamente."
 Getnet,Getnet
 Due,Vencimento
 Instruction,Instrução


### PR DESCRIPTION
Em caso de erro na API de tokenização da GetNet, a API `V1/guest-carts/:cartId/generate-credit-card-number-token` passa a retornar uma mensagem de erro, evitando um erro de referência nula no JavaScript.